### PR TITLE
Improve copy-to-clipboard, fix home link, clean up exampleSite

### DIFF
--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -83,7 +83,7 @@ You also can disable mermaid for specific pages while globally enabled.
 
 ## Home Button Configuration
 
-If the `disableLandingPage` option is set to `false`, a Home button will appear
+If the `disableLandingPageButton` option is set to `false`, a Home button will appear
 on the left menu. It is an alternative for clicking on the logo. To edit the
 appearance, you will have to configure two parameters for the defined languages:
 

--- a/exampleSite/content/basics/customization/_index.en.md
+++ b/exampleSite/content/basics/customization/_index.en.md
@@ -90,12 +90,15 @@ If you need to change this default behavior, create a new file in `layouts/parti
 First, create a new CSS file in your local `static/css` folder prefixed by `theme` (e.g. with _mine_ theme `static/css/theme-mine.css`). Copy the following content and modify colors in CSS variables.
 
 ```css
-:root{
+:root {
     --MAIN-TEXT-color:#323232; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #5e5e5e; /* Color of titles h2-h3-h4-h5 */
     --MAIN-LINK-color:#1C90F3; /* Color of links */
     --MAIN-LINK-HOVER-color:#167ad0; /* Color of hovered links */
     --MAIN-ANCHOR-color: #1C90F3; /* color of anchors on titles */
+
+    --MENU-HOME-LINK-color: #323232; /* Color of the home button text */
+    --MENU-HOME-LINK-HOVER-color: #5e5e5e; /* Color of the hovered home button text */
 
     --MENU-HEADER-BG-color:#1C90F3; /* Background color of menu header */
     --MENU-HEADER-BORDER-color:#33a1ff; /*Color of menu header border */
@@ -155,21 +158,26 @@ a:hover {
     transition: width 0.5s ease;
     background-color: var(--MAIN-LINK-HOVER-color);
 }
+
 #sidebar {
     background-color: var(--MENU-SECTIONS-BG-color);
 }
+
 #sidebar #header-wrapper {
     background: var(--MENU-HEADER-BG-color);
     color: var(--MENU-SEARCH-BOX-color);
     border-color: var(--MENU-HEADER-BORDER-color);
 }
+
 #sidebar .searchbox {
     border-color: var(--MENU-SEARCH-BOX-color);
     background: var(--MENU-SEARCH-BG-color);
 }
+
 #sidebar ul.topics > li.parent, #sidebar ul.topics > li.active {
     background: var(--MENU-SECTIONS-ACTIVE-BG-color);
 }
+
 #sidebar .searchbox * {
     color: var(--MENU-SEARCH-BOX-ICONS-color);
 }
@@ -189,6 +197,28 @@ a:hover {
 
 #sidebar hr {
     border-color: var(--MENU-SECTION-HR-color);
+}
+
+#body .tags a.tag-link {
+    background-color: var(--MENU-HEADER-BG-color);
+}
+
+#body .tags a.tag-link:before {
+    border-right-color: var(--MENU-HEADER-BG-color);
+}
+
+#homelinks {
+    background: var(--MENU-HEADER-BG-color);
+    background-color: var(--MENU-HEADER-BORDER-color);
+    border-bottom-color: var(--MENU-HEADER-BORDER-color);
+}
+
+#homelinks a {
+    color: var(--MENU-HOME-LINK-color);
+}
+
+#homelinks a:hover {
+    color: var(--MENU-HOME-LINK-HOVER-color);
 }
 ```
 

--- a/exampleSite/content/basics/installation/_index.en.md
+++ b/exampleSite/content/basics/installation/_index.en.md
@@ -43,7 +43,7 @@ Chapters are pages that contain other child pages. It has a special layout style
 
 # Basics
 
-Discover what this H(tugo theme is all about and the core concepts behind it.
+Discover what this Hugo theme is all about and the core concepts behind it.
 ```
 
 renders as

--- a/exampleSite/content/cont/syntaxhighlight.en.md
+++ b/exampleSite/content/cont/syntaxhighlight.en.md
@@ -4,7 +4,7 @@ title: Code highlighting
 weight: 16
 ---
 
-Relearn theme uses [Hugos build in syntax highlighting](https://gohugo.io/content-management/syntax-highlighting/) for code.
+Relearn theme uses [Hugo's built-in syntax highlighting](https://gohugo.io/content-management/syntax-highlighting/) for code.
 
 ## Markdown syntax
 
@@ -48,7 +48,7 @@ Renders to:
 
 ## Supported languages
 
-Hugo comes with a [remarkable list](https://gohugo.io/content-management/syntax-highlighting/) of supported languages.
+Hugo comes with a [remarkable list](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) of supported languages.
 
 ## Configuration
 

--- a/exampleSite/layouts/partials/logo.html
+++ b/exampleSite/layouts/partials/logo.html
@@ -6,7 +6,7 @@
     font-weight: bold;
     margin-top: -2px;
   "
-  href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>
+  href="{{ .Site.Params.landingPageURL | default "/" | relLangURL }}">
   <svg
   style="
     height: 65px;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -92,7 +92,7 @@
         <div id="body-inner">
           {{if and (not .IsHome) (not .Params.chapter) }}
             <h1>
-              {{ if or (eq .Kind "taxonomy") (eq .Kind "term") }}
+              {{ if eq .Kind "term" }}
                 {{.Data.Singular}} ::
               {{ end }}
               {{.Title}}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -6,7 +6,7 @@
     font-weight: bold;
     margin-top: -2px;
   "
-  href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>
+  href="{{ .Site.Params.landingPageURL | default "/" | relLangURL }}">
   <svg
   style="
     height: 65px;

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -14,7 +14,7 @@
     <section id="homelinks">
       <ul>
         <li>
-            <a class="padding" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>{{ safeHTML (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-home'></i> Home") }}</a>
+            <a class="padding" href="{{ .Site.Params.landingPageURL | default "/" | relLangURL }}">{{ .Site.Params.landingPageName | default `<i class="fas fa-home"></i> Home` | safeHTML }}</a>
         </li>
       </ul>
     </section>

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.72.0"
+  HUGO_VERSION = "0.87.0"
 
 [context.production.environment]
   HUGO_BASEURL = "https://relearn.netlify.app/"

--- a/static/css/theme-blue.css
+++ b/static/css/theme-blue.css
@@ -1,4 +1,4 @@
-:root{
+:root {
     --MAIN-TEXT-color:#323232; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #5e5e5e; /* Color of titles h2-h3-h4-h5 */
     --MAIN-LINK-color:#1C90F3; /* Color of links */
@@ -24,7 +24,6 @@
 
     --MENU-VISITED-color: #33a1ff; /* Color of 'page visited' icons in menu */
     --MENU-SECTION-HR-color: #20272b; /* Color of <hr> separator in menu */
-
 }
 
 body {
@@ -67,21 +66,26 @@ a:hover {
     transition: width 0.5s ease;
     background-color: var(--MAIN-LINK-HOVER-color);
 }
+
 #sidebar {
     background-color: var(--MENU-SECTIONS-BG-color);
 }
+
 #sidebar #header-wrapper {
     background: var(--MENU-HEADER-BG-color);
     color: var(--MENU-SEARCH-BOX-color);
     border-color: var(--MENU-HEADER-BORDER-color);
 }
+
 #sidebar .searchbox {
     border-color: var(--MENU-SEARCH-BOX-color);
     background: var(--MENU-SEARCH-BG-color);
 }
+
 #sidebar ul.topics > li.parent, #sidebar ul.topics > li.active {
     background: var(--MENU-SECTIONS-ACTIVE-BG-color);
 }
+
 #sidebar .searchbox * {
     color: var(--MENU-SEARCH-BOX-ICONS-color);
 }
@@ -112,15 +116,15 @@ a:hover {
 }
 
 #homelinks {
-  background: var(--MENU-HEADER-BG-color);
-  background-color: var(--MENU-HEADER-BORDER-color);
-  border-bottom-color: var(--MENU-HEADER-BORDER-color);
+    background: var(--MENU-HEADER-BG-color);
+    background-color: var(--MENU-HEADER-BORDER-color);
+    border-bottom-color: var(--MENU-HEADER-BORDER-color);
 }
 
 #homelinks a {
-  color: var(--MENU-HOME-LINK-color);
+    color: var(--MENU-HOME-LINK-color);
 }
 
 #homelinks a:hover {
-  color: var(--MENU-HOME-LINK-HOVERED-color);
+    color: var(--MENU-HOME-LINK-HOVER-color);
 }

--- a/static/css/theme-green.css
+++ b/static/css/theme-green.css
@@ -1,4 +1,4 @@
-:root{
+:root {
     --MAIN-TEXT-color:#323232; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #5e5e5e; /* Color of titles h2-h3-h4-h5 */
     --MAIN-LINK-color:#599a3e; /* Color of links */
@@ -24,7 +24,6 @@
 
     --MENU-VISITED-color: #599a3e; /* Color of 'page visited' icons in menu */
     --MENU-SECTION-HR-color: #18211c; /* Color of <hr> separator in menu */
-
 }
 
 body {
@@ -67,21 +66,26 @@ a:hover {
     transition: width 0.5s ease;
     background-color: var(--MAIN-LINK-HOVER-color);
 }
+
 #sidebar {
     background-color: var(--MENU-SECTIONS-BG-color);
 }
+
 #sidebar #header-wrapper {
     background: var(--MENU-HEADER-BG-color);
     color: var(--MENU-SEARCH-BOX-color);
     border-color: var(--MENU-HEADER-BORDER-color);
 }
+
 #sidebar .searchbox {
     border-color: var(--MENU-SEARCH-BOX-color);
     background: var(--MENU-SEARCH-BG-color);
 }
+
 #sidebar ul.topics > li.parent, #sidebar ul.topics > li.active {
     background: var(--MENU-SECTIONS-ACTIVE-BG-color);
 }
+
 #sidebar .searchbox * {
     color: var(--MENU-SEARCH-BOX-ICONS-color);
 }
@@ -112,15 +116,15 @@ a:hover {
 }
 
 #homelinks {
-  background: var(--MENU-HEADER-BG-color);
-  background-color: var(--MENU-HEADER-BORDER-color);
-  border-bottom-color: var(--MENU-HEADER-BORDER-color);
+    background: var(--MENU-HEADER-BG-color);
+    background-color: var(--MENU-HEADER-BORDER-color);
+    border-bottom-color: var(--MENU-HEADER-BORDER-color);
 }
 
 #homelinks a {
-  color: var(--MENU-HOME-LINK-color);
+    color: var(--MENU-HOME-LINK-color);
 }
 
 #homelinks a:hover {
-  color: var(--MENU-HOME-LINK-HOVERED-color);
+    color: var(--MENU-HOME-LINK-HOVER-color);
 }

--- a/static/css/theme-red.css
+++ b/static/css/theme-red.css
@@ -1,4 +1,4 @@
-:root{
+:root {
     --MAIN-TEXT-color:#323232; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #5e5e5e; /* Color of titles h2-h3-h4-h5 */
     --MAIN-LINK-color:#f31c1c; /* Color of links */
@@ -24,7 +24,6 @@
 
     --MENU-VISITED-color: #ff3333; /* Color of 'page visited' icons in menu */
     --MENU-SECTION-HR-color: #2b2020; /* Color of <hr> separator in menu */
-
 }
 
 body {
@@ -67,21 +66,26 @@ a:hover {
     transition: width 0.5s ease;
     background-color: var(--MAIN-LINK-HOVER-color);
 }
+
 #sidebar {
     background-color: var(--MENU-SECTIONS-BG-color);
 }
+
 #sidebar #header-wrapper {
     background: var(--MENU-HEADER-BG-color);
     color: var(--MENU-SEARCH-BOX-color);
     border-color: var(--MENU-HEADER-BORDER-color);
 }
+
 #sidebar .searchbox {
     border-color: var(--MENU-SEARCH-BOX-color);
     background: var(--MENU-SEARCH-BG-color);
 }
+
 #sidebar ul.topics > li.parent, #sidebar ul.topics > li.active {
     background: var(--MENU-SECTIONS-ACTIVE-BG-color);
 }
+
 #sidebar .searchbox * {
     color: var(--MENU-SEARCH-BOX-ICONS-color);
 }
@@ -112,15 +116,15 @@ a:hover {
 }
 
 #homelinks {
-  background: var(--MENU-HEADER-BG-color);
-  background-color: var(--MENU-HEADER-BORDER-color);
-  border-bottom-color: var(--MENU-HEADER-BORDER-color);
+    background: var(--MENU-HEADER-BG-color);
+    background-color: var(--MENU-HEADER-BORDER-color);
+    border-bottom-color: var(--MENU-HEADER-BORDER-color);
 }
 
 #homelinks a {
-  color: var(--MENU-HOME-LINK-color);
+    color: var(--MENU-HOME-LINK-color);
 }
 
 #homelinks a:hover {
-  color: var(--MENU-HOME-LINK-HOVERED-color);
+    color: var(--MENU-HOME-LINK-HOVER-color);
 }

--- a/static/css/theme-relearn.css
+++ b/static/css/theme-relearn.css
@@ -1,4 +1,4 @@
-:root{
+:root {
     --MAIN-TEXT-color:#323232; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #444753; /* Color of titles h2-h3-h4-h5 */
     --MAIN-LINK-color:#486ac9; /* Color of links */
@@ -24,7 +24,6 @@
 
     --MENU-VISITED-color: #506397; /* Color of 'page visited' icons in menu */
     --MENU-SECTION-HR-color: #28292e; /* Color of <hr> separator in menu */
-
 }
 
 body {
@@ -67,21 +66,26 @@ a:hover {
     transition: width 0.5s ease;
     background-color: var(--MAIN-LINK-HOVER-color);
 }
+
 #sidebar {
     background-color: var(--MENU-SECTIONS-BG-color);
 }
+
 #sidebar #header-wrapper {
     background: var(--MENU-HEADER-BG-color);
     color: var(--MENU-SEARCH-BOX-color);
     border-color: var(--MENU-HEADER-BORDER-color);
 }
+
 #sidebar .searchbox {
     border-color: var(--MENU-SEARCH-BOX-color);
     background: var(--MENU-SEARCH-BG-color);
 }
+
 #sidebar ul.topics > li.parent, #sidebar ul.topics > li.active {
     background: var(--MENU-SECTIONS-ACTIVE-BG-color);
 }
+
 #sidebar .searchbox * {
     color: var(--MENU-SEARCH-BOX-ICONS-color);
 }
@@ -112,19 +116,19 @@ a:hover {
 }
 
 #homelinks {
-  background: var(--MENU-HEADER-BG-color);
-  background-color: var(--MENU-HEADER-BORDER-color);
-  border-bottom-color: var(--MENU-HEADER-BORDER-color);
+    background: var(--MENU-HEADER-BG-color);
+    background-color: var(--MENU-HEADER-BORDER-color);
+    border-bottom-color: var(--MENU-HEADER-BORDER-color);
 }
 
 #homelinks a {
-  color: var(--MENU-HOME-LINK-color);
+    color: var(--MENU-HOME-LINK-color);
 }
 
 #homelinks a:hover {
-  color: var(--MENU-HOME-LINK-HOVERED-color);
+    color: var(--MENU-HOME-LINK-HOVER-color);
 }
 
-#shortcuts h3{
+#shortcuts h3 {
     color: var(--MENU-SECTIONS-LINK-HOVER-color) !important;
 }

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -63,7 +63,6 @@ a:hover {
 }
 pre {
     position: relative;
-    color: #ffffff;
 }
 .bg {
     background: #fff;
@@ -1140,10 +1139,6 @@ pre .copy-to-clipboard:hover {
   color: #fff;
   padding: 7px 0;
   border-bottom: 4px solid #9c6fb6;
-}
-
-#searchResults {
-    text-align: left;
 }
 
 option {

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -624,7 +624,7 @@ section.attachments.neutral > div.label {
 
 code, kbd, pre, samp {
     font-family: "Consolas", menlo, monospace;
-    font-size: 14.75px;
+    font-size: 92%;
     vertical-align: baseline;
 }
 code {
@@ -1068,17 +1068,14 @@ td {
     background-image: url(../images/clippy.svg);
     background-position: 50% 50%;
     background-repeat: no-repeat;
-    background-size: 16px 16px;
+    background-size: 14px 16px;
     border: 1px solid #F8E8C8;
-    border-radius: 2px;
+    border-radius: 0 2px 2px 0;
     color: #5E5E5E;
     cursor: pointer;
-    font-size: 14.75px;
-    display: inline-block;
-    padding: 11px 13px;
-    position: relative;
-    top: 1.75px;
-    vertical-align: top;
+    font-family: "Consolas", menlo, monospace;
+    font-size: 92%;
+    padding-left: 22px;
 }
 .copy-to-clipboard:hover {
     background-color: #FCEBB4;
@@ -1087,7 +1084,8 @@ td {
 pre .copy-to-clipboard {
     background-color: rgba( 204, 204, 204, .666 );
     border-color: #000;
-    padding: 10.5px 13.5px;
+    border-radius: 2px;
+    padding: 10.5px 12.5px;
     position: absolute;
     right: 4px;
     top: 4px;


### PR DESCRIPTION
Some fixes and clean-ups:
* copy-to-clipboard icon looked stretched
* Home link didn't work correctly when base URL has some path
* Typo in custom theme's variable: --MENU-HOME-LINK-HOVER**ED**-color
* Fixed some exampleSite typos and other minor clean-ups