### PR TITLE
Fix search with relativeURLs

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -2,7 +2,7 @@
 {{- if ne $page.Type "json" -}}
 {{- if and $index (gt $index 0) -}},{{- end }}
 {
-	"uri": "{{ $page.Permalink }}",
+	"uri": "{{ $page.RelPermalink }}",
 	"title": "{{ htmlEscape $page.Title}}",
 	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
 	"description": "{{ htmlEscape .Description}}",

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -7,10 +7,10 @@
 <script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 <script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 <script type="text/javascript">
-    {{ if .Site.IsMultiLingual }}
-        var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
-    {{ else }}
-        var baseurl = "{{.Site.BaseURL}}";
-    {{ end }}
+    // hack to let hugo tell us how to get to the root when using relativeURLs, it needs to be called *url= for it to do its magic:
+    // https://github.com/gohugoio/hugo/blob/145b3fcce35fbac25c7033c91c1b7ae6d1179da8/transform/urlreplacers/absurlreplacer.go#L72
+    var index_url={{"index.json" | relLangURL}};
+    var root_url="/";
+    var baseUri=root_url.replace(/\/$/, '');
 </script>
 <script type="text/javascript" src="{{"js/search.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -6,12 +6,8 @@ function endsWith(str, suffix) {
 
 // Initialize lunrjs using our generated index file
 function initLunr() {
-    if (!endsWith(baseurl,"/")){
-        baseurl = baseurl+'/'
-    };
-
     // First retrieve the index file
-    $.getJSON(baseurl +"index.json")
+    $.getJSON(index_url)
         .done(function(index) {
             pagesIndex = index;
             // Set up lunrjs by declaring the fields we use
@@ -82,7 +78,7 @@ $( document ).ready(function() {
             divsuggestion.className = "autocomplete-suggestion";
             divsuggestion.setAttribute("data-term", term);
             divsuggestion.setAttribute("data-title", item.title);
-            divsuggestion.setAttribute("data-uri", item.uri);
+            divsuggestion.setAttribute("data-uri", baseUri + item.uri);
             divsuggestion.setAttribute("data-context", item.context);
             divsuggestion.innerText = '» ' + item.title;
             divsuggestion.appendChild(divcontext);


### PR DESCRIPTION
The search currently doesn't work properly when using `relativeURLs` and serving the site in some subpath, as it will always try to load the search index from `/index.json`, instead of being relative to the current page.