### PR TITLE
Add menu-pre and menu-post templates

### DIFF
--- a/exampleSite/content/basics/_index.en.md
+++ b/exampleSite/content/basics/_index.en.md
@@ -1,8 +1,7 @@
 +++
 chapter = true
-pre = "<b>1. </b>"
 title = "Basics"
-weight = 5
+weight = 1
 +++
 
 ### Chapter 1

--- a/exampleSite/content/cont/_index.en.md
+++ b/exampleSite/content/cont/_index.en.md
@@ -1,8 +1,7 @@
 +++
 chapter = true
-pre = "<b>2. </b>"
 title = "Content"
-weight = 10
+weight = 2
 +++
 
 ### Chapter 2

--- a/exampleSite/content/shortcodes/_index.en.md
+++ b/exampleSite/content/shortcodes/_index.en.md
@@ -1,8 +1,7 @@
 +++
 chapter = true
-pre = "<b>3. </b>"
 title = "Shortcodes"
-weight = 15
+weight = 3
 +++
 
 ### Chapter 3

--- a/exampleSite/layouts/partials/menu-pre.html
+++ b/exampleSite/layouts/partials/menu-pre.html
@@ -1,0 +1,1 @@
+{{ if .Params.chapter }}<b>{{ .Params.weight }}. </b>{{ end }}

--- a/layouts/partials/menu-post.html
+++ b/layouts/partials/menu-post.html
@@ -1,0 +1,1 @@
+{{ .Params.Post | safeHTML }}

--- a/layouts/partials/menu-pre.html
+++ b/layouts/partials/menu-pre.html
@@ -1,0 +1,1 @@
+{{ .Params.Pre | safeHTML }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -110,7 +110,7 @@
       {{ $currentAlwaysopen := .Params.alwaysopen | default $alwaysopen }}
       <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item{{if eq .File.UniqueID $currentFileUniqueID}} active{{else if .IsAncestor $currentNode }} parent{{else if $currentAlwaysopen}} parent{{end}}">
         <a href="{{.RelPermalink}}">
-          {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
+          {{ partial "menu-pre.html" . }}{{or .Params.menuTitle .LinkTitle .Title}}{{ partial "menu-post.html" . }}
           {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
         </a>
         {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
@@ -143,7 +143,7 @@
     {{else if not .Params.Hidden }}
       <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item{{if eq .File.UniqueID $currentFileUniqueID}} active{{end}}">
         <a href="{{ .RelPermalink}}">
-          {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
+          {{ partial "menu-pre.html" . }}{{or .Params.menuTitle .LinkTitle .Title}}{{ partial "menu-post.html" . }}
           {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
         </a>
       </li>


### PR DESCRIPTION
This PR adds partial templates `menu-pre.html` and `menu-post.html` to allow easier customisation of the menu look & feel. I have a use-case where I want to add a badge to each menu entry based on a property in that page front matter. That's already possible with the `pre` field but that leads to too much duplication as I'd have to write the full HTML for the badge in every page. I'd like to just have a page property like `status: ok` or `status: failed` and then have the respective HTML for the badge in  `menu-pre.html`.