### PR TITLE
Register focus event in the search text input

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -47,7 +47,8 @@ function initLunr() {
  */
 function search(queryTerm) {
     // Find the item in our index corresponding to the lunr one to have more info
-    return lunrIndex.search(queryTerm+"^100"+" "+queryTerm+"*^10"+" "+"*"+queryTerm+"^10"+" "+queryTerm+"~2^1").map(function(result) {
+    var searchTerm = queryTerm.match(/\w+/g).map(word => word+"^100"+" "+word+"*^10"+" "+"*"+word+"^10"+" "+word+"~2^1").join(" ");
+    return lunrIndex.search(searchTerm).map(function(result) {
             return pagesIndex.filter(function(page) {
                 return page.uri === result.ref;
             })[0];
@@ -69,7 +70,7 @@ $( document ).ready(function() {
             var numContextWords = 2;
             var text = item.content.match(
                 "(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}" +
-                    term+"(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}");
+                    term.trim()+"(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}");
             item.context = text;
             var divcontext = document.createElement("div");
             divcontext.className = "context";
@@ -89,4 +90,9 @@ $( document ).ready(function() {
             location.href = item.getAttribute('data-uri');
         }
     });
+
+    // JavaScript-autoComplete only registers the focus event when minChars is 0 which doesn't make sense, let's do it ourselves
+    // https://github.com/Pixabay/JavaScript-autoComplete/blob/master/auto-complete.js#L191
+    var selector = $("#search-by").get(0);
+    $(selector).focus(selector.focusHandler);
 });


### PR DESCRIPTION
This was initially only meant to address the search input focus, because when searching something, it's common that we'll not find what we are looking for straightaway, and need to go through several pages. Currently, after opening a page from a previous search the text in the search input is preserved which is useful, but it's not easy to open a different page from the same search results after that. Simply focusing the text input doesn't show the search results, until some key is pressed, but even just pressing space to see the search results changes the results list itself.

But then I started wondering why a space would change the results, as that's just counter-intuitive. The problem is how the Lunr search pattern is being built. It has boosts and wildcards, and if you search for `tags`, the theme will send `tags^100 tags*^10 *tags^10 tags~2^1` to Lunr, which is fine. But if you add an extra space, like `tags `, the pattern will look like this `tags ^100 tags *^10 *tags ^10 tags ~2^1`. Lunr seems to be ok when there are spaces between words and boosts, but not between words and wildcards, so the search will be composed by the terms `tags^100`, `tags`, `*^10`, `*tags^10` and `tags~2^1`. The term `*^10` will be by itself, which just matches any word, so the pages with greater number of words will have higher scores, regardless whether they have the word `tags` in them. The correct way is to apply the current pattern word by word (ignoring all spaces).