### PR TITLE
Fix index.json encoding

### DIFF
--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -23,6 +23,8 @@ Note that some of these parameters are explained in details in other sections of
   showVisitedLinks = false
   # Disable search function. It will hide search bar
   disableSearch = false
+  # Make hidden pages searchable
+  searchHiddenPages = false
   # Javascript and CSS cache are automatically busted when new version of site is generated.
   # Set this to true to disable this behavior (some proxies don't handle well this optimization)
   disableAssetsBusting = false

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,12 +1,7 @@
-[{{ range $index, $page := .Site.Pages }}
-{{- if ne $page.Type "json" -}}
-{{- if and $index (gt $index 0) -}},{{- end }}
-{
-	"uri": "{{ $page.RelPermalink }}",
-	"title": "{{ htmlEscape $page.Title}}",
-	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
-	"description": "{{ htmlEscape .Description}}",
-	"content": {{$page.Plain | jsonify}}
-}
-{{- end -}}
-{{- end -}}]
+{{- $pages := slice }}
+{{- range .Site.Pages }}
+{{- if or .Site.Params.searchHiddenPages (and (ne .Params.hidden true) (ne .Title "")) }}
+{{- $pages = $pages | append (dict "uri" .RelPermalink "title" .Title "tags" .Params.tags "description" .Description "content" (.Plain | htmlUnescape)) }}
+{{- end }}
+{{- end }}
+{{- $pages | jsonify (dict "indent" "  ") }}


### PR DESCRIPTION
`index.json` is currently overly escaped, which makes strange characters appear in the search context preview.

This also removes hidden pages from the search.