### PR TITLE
Custom Notice Titles

### DIFF
--- a/exampleSite/content/shortcodes/notice.en.md
+++ b/exampleSite/content/shortcodes/notice.en.md
@@ -8,10 +8,14 @@ The notice shortcode shows four types of disclaimers to help you structure your 
 ## Usage
 
 ````go
-{{%/* notice [ note | info | tip | warning ] */%}}
+{{%/* notice [ note | info | tip | warning ] [?string] */%}}
 Some markup
 {{%/* /notice */%}}
 ````
+
+The first parameter is required and indicates the type of notice.
+
+The second parameter is optional. If provided, it will be used as the title of the notice. If not provided, then the type of notice will be used as the title. For example, the title of a warning notice will be "Warning".
 
 ## Examples
 
@@ -190,3 +194,17 @@ You can add:
 {{%/* /notice */%}}
 ````
 {{% /expand %}}
+
+### Notice with Custom Title
+
+You can customize the title of the notice by passing it as a second parameter.
+
+````go
+{{%/* notice note "Pay Attention to this Note!" */%}}
+The title is now the parameter that was provided.
+{{%/* /notice */%}}
+````
+
+{{% notice note "Pay Attention to this Note!" %}}
+The title is now the parameter that was provided.
+{{% /notice %}}

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,6 +1,6 @@
 {{- $_hugo_config := `{ "version": 1 }` }}
 {{- $style := .Get 0 }}
-{{- $title := $style | T }}
+{{- $title := .Get 1 | default ($style | T) }}
 <div class="notices {{ $style }}">
     <div class="label">{{ $title }}</div>
     {{- .Inner }}


### PR DESCRIPTION
Adds support for providing custom titles to notices #124 .

Usage

```go
{{% notice note "Pay Attention to this Note!" %}}
The title is now the parameter that was provided.
{{% /notice %}}
```
<img width="850" alt="Screen Shot 2021-10-21 at 7 23 09 PM" src="https://user-images.githubusercontent.com/32286773/138383087-27b34fea-720c-4c6e-bb08-d0420571ccd5.png">

This change is backwards compatible and will default to the current behavior when the second parameter is not provided.

```go
{{% notice note %}}
The title is "Note"
{{% /notice %}}
```
<img width="850" alt="Screen Shot 2021-10-21 at 7 25 02 PM" src="https://user-images.githubusercontent.com/32286773/138383257-817ee46b-0eb5-4250-917b-f4293127585e.png">


