### PR TITLE
Fix icon filename extension

### DIFF
--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -4,11 +4,11 @@
 {{- else if (fileExists "/static/images/favicon.png") -}}
     <link rel="icon" href="{{ "/images/favicon.png" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/png">
 {{- else if (fileExists "/static/images/favicon.ico") -}}
-    <link rel="icon" href="{{ "/images/favicon.icon" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/x-icon">
+    <link rel="icon" href="{{ "/images/favicon.ico" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/x-icon">
 {{- else if (fileExists "/static/images/logo.svg") -}}
     <link rel="icon" href="{{ "/images/logo.svg" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/svg+xml">
 {{- else if (fileExists "/static/images/logo.png") -}}
     <link rel="icon" href="{{ "/images/logo.png" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/png">
 {{- else if (fileExists "/static/images/logo.ico") -}}
-    <link rel="icon" href="{{ "/images/logo.icon" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/x-icon">
+    <link rel="icon" href="{{ "/images/logo.ico" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" type="image/x-icon">
 {{- end }}


### PR DESCRIPTION
If `favicon.ico` or `logo.ico` exists, `/images/favicon.icon`  or `/images/logo.icon`  should be `/images/favicon.ico`  or `/images/logo.ico`.