### PR TITLE
add i18n support for navigation toggle

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -25,6 +25,9 @@ other = "More"
 [Expand-title]
 other = "Expand me..."
 
+[navigation-toggle]
+other = "navigation"
+
 [Byte-symbol]
 other = "B"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -25,6 +25,9 @@ other = "更多"
 [Expand-title]
 other = "展开"
 
+[navigation-toggle]
+other = "导航"
+
 [Byte-symbol]
 other = "B"
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{- partial "header.html" . }}
 <span id="sidebar-toggle-span">
-<a href="#" id="sidebar-toggle" data-sidebar-toggle=""><i class="fas fa-bars"></i> navigation</a>
+<a href="#" id="sidebar-toggle" data-sidebar-toggle=""><i class="fas fa-bars"></i>{{T "navigation-toggle"}}</a>
 </span>
 
 {{if .Site.Home.Content }}


### PR DESCRIPTION
Although the toggle only appears when the page is too thin to show both navigation and content, adding i18n support do no harm.