### PR TITLE
Add the Dynamic Collapsible Tree Menu support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,6 +42,7 @@ title = "Hugo Relearn Documentation"
   # graphs; you usually will not need it and you should remove this for
   # security reasons
   mermaidInitialize = "{ \"securityLevel\": \"loose\"}"
+  collapsibleMenu = true
 
 [outputs]
   # add JSON to the home page to support lunr search; This is a mandatory setting

--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -66,6 +66,8 @@ Note that some of these parameters are explained in details in other sections of
   custom_css = ["css/foo.css", "css/bar.css"]
   # Change the title separator. Default to "::".
   titleSeparator = "-"
+  # If set to true, the menu in the sidebar will be displayed in a collapsible tree view.
+  collapsibleMenu = false
 ```
 
 ## A word on running your site in a subfolder

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -27,7 +27,8 @@
       </div>
       {{- end }}
       <div id="content-wrapper" class="highlightable">
-        <ul class="topics">
+        {{- $collapsibleMenu := .Site.Params.collapsibleMenu | default false }}
+        <ul class="topics{{ if .Site.Params.CollapsibleMenu }} collapsible-menu{{ end }}">
           {{- $defaultOrdersectionsby := .Site.Params.ordersectionsby | default "weight" }}
           {{- $currentOrdersectionsby := .Site.Home.Params.ordersectionsby | default $defaultOrdersectionsby }}
           {{- $defaultAlwaysopen := .Site.Params.alwaysopen | default false }}
@@ -143,7 +144,10 @@
           {{- $defaultOrdersectionsby := .Site.Params.ordersectionsby | default "weight" }}
           {{- $currentOrdersectionsby := .Params.ordersectionsby | default $defaultOrdersectionsby }}
           {{- $currentAlwaysopen := .Params.alwaysopen | default $alwaysopen }}
-          <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item{{if eq .RelPermalink $currentFileRelPermalink}} active{{end}}{{if .IsAncestor $currentNode }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}"><a href="{{.RelPermalink}}">
+          {{- $collapsibleMenu := .Site.Params.collapsibleMenu | default false }}
+          {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
+          <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item{{if eq .RelPermalink $currentFileRelPermalink}} active{{end}}{{if .IsAncestor $currentNode }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}">
+          {{ if and $collapsibleMenu (ne $numberOfPages 0) }}<input type="checkbox" id="section-{{ md5 .Page }}" class="toggle" {{ if .IsAncestor $currentNode }}checked{{ end }} /><label for="section-{{ md5 .Page }}" class="flex justify-between"></label>{{ end }}<a href="{{.RelPermalink}}">
               {{- partial "menu-pre.html" . }}{{ or .Params.menuTitle .LinkTitle .Title }}{{ partial "menu-post.html" . }}
               {{- if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}</a><ul>
               {{- $pages := .Pages }}

--- a/layouts/partials/stylesheet.html
+++ b/layouts/partials/stylesheet.html
@@ -15,6 +15,9 @@
     {{- range .Site.Params.custom_css }}
     <link href="{{(printf "%s" .) | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     {{- end }}
+    {{- if .Site.Params.collapsibleMenu }}
+    <link href="{{"css/collapsible-menu.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
+    {{- end }}
     <style>
     {{- if .Site.Params.disableInlineCopyToClipBoard }}
       :not(pre) > code.copy-to-clipboard-code + span.copy-to-clipboard-button {

--- a/static/css/collapsible-menu.css
+++ b/static/css/collapsible-menu.css
@@ -1,0 +1,133 @@
+#sidebar ul.collapsible-menu li a {
+    display: inline-block;
+}
+
+#sidebar ul.collapsible-menu {
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+#sidebar .collapsible-menu {
+    transition: .2s ease-in-out;
+    transition-property: transform, margin, opacity, visibility;
+    will-change:transform, margin, opacity;
+
+    overflow-x: hidden;
+    overflow-y: auto
+}
+
+#sidebar .collapsible-menu input.toggle {
+	position: absolute;
+	left: 0;
+	top: 0;
+	opacity: 0;
+	cursor: pointer;
+    overflow: hidden;
+    position:absolute
+}
+
+#sidebar .collapsible-menu li {
+    position: relative;
+    user-select: none;
+}
+
+#sidebar .collapsible-menu label {
+    cursor: pointer;
+    word-wrap: break-word;
+	display: inline-block;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+#sidebar .collapsible-menu a {
+    cursor: pointer;
+    word-wrap: break-word;
+}
+
+#sidebar .collapsible-menu input.toggle+label+a+ul {
+    overflow: hidden !important;
+    display: none !important;
+}
+
+#sidebar .collapsible-menu input.toggle:checked+label+a+ul {
+	display: inline !important;
+}
+
+#sidebar .collapsible-menu input.toggle:checked+label+a+ul > li {
+	display: block !important;
+}
+
+#sidebar .collapsible-menu input.toggle:checked+label+a+ul {
+	height: auto;
+    display: inline;
+}
+
+#sidebar .collapsible-menu input.toggle+label:after {
+    width: 1rem;
+    height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    content: "▸";
+    color: var(--MENU-SECTIONS-LINK-color, #bababa);
+}
+
+#sidebar .collapsible-menu input.toggle:checked+label:after {
+    width: 1rem;
+    height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    content: "▾";
+    color: var(--MENU-SECTIONS-LINK-color, #bababa);
+}
+
+#sidebar ul.collapsible-menu li.active > a {
+    margin-left: 0;
+    padding-left: 0.5rem;
+    width: calc(100% - 2rem);
+}
+
+#sidebar ul.collapsible-menu > li.active > a, #sidebar ul.collapsible-menu > li > a {
+    margin-left: 0;
+    padding-left: 0.25rem;
+    width: calc(100% - 2rem) !important;
+    padding-right: 0;
+}
+
+#sidebar ul.collapsible-menu > li.parent, #sidebar ul.collapsible-menu > li.active {
+    margin-left: 0;
+    padding-left: 0;
+}
+
+#sidebar ul.collapsible-menu li > a {
+    width: calc(100% - 2rem);
+    left: 3rem;
+    margin-right: 0;
+}
+
+#sidebar ul.collapsible-menu li input:checked a {
+    padding-left: 0;
+}
+
+#sidebar ul.collapsible-menu ul > li > input:checked+label+a {
+    display: inline-block;
+    margin-left: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+#sidebar ul.collapsible-menu ul > li > input:checked+label+a > li > a:nth-child(1):nth-last-child(1){
+    margin-left: 2rem;
+}
+
+#sidebar ul.collapsible-menu li > a:nth-child(1)  {
+    margin-left: 1.5rem;
+    width: calc(100% - 2.5rem) !important;
+    padding-left: 0;
+    padding-right: 0 !important;
+}

--- a/static/css/collapsible-menu.css
+++ b/static/css/collapsible-menu.css
@@ -86,28 +86,6 @@
     color: var(--MENU-SECTIONS-LINK-color, #bababa);
 }
 
-#sidebar .collapsible-menu input.toggle+label:after:hover {
-    width: 1rem;
-    height: 1rem;
-    max-width: 1rem;
-    max-height: 1rem;
-    max-width: 1rem;
-    max-height: 1rem;
-    content: "▸";
-    color: var(--MENU-SECTIONS-LINK-HOVER-color, #e6e6e6);
-}
-
-#sidebar .collapsible-menu input.toggle:checked+label:after {
-    width: 1rem;
-    height: 1rem;
-    max-width: 1rem;
-    max-height: 1rem;
-    max-width: 1rem;
-    max-height: 1rem;
-    content: "▾";
-    color: var(--MENU-SECTIONS-LINK-color, #bababa);
-}
-
 #sidebar ul.collapsible-menu li.active > a {
     margin-left: 0;
     padding-left: 0.5rem;

--- a/static/css/collapsible-menu.css
+++ b/static/css/collapsible-menu.css
@@ -86,6 +86,28 @@
     color: var(--MENU-SECTIONS-LINK-color, #bababa);
 }
 
+#sidebar .collapsible-menu input.toggle+label:after:hover {
+    width: 1rem;
+    height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    content: "▸";
+    color: var(--MENU-SECTIONS-LINK-HOVER-color, #e6e6e6);
+}
+
+#sidebar .collapsible-menu input.toggle:checked+label:after {
+    width: 1rem;
+    height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    max-width: 1rem;
+    max-height: 1rem;
+    content: "▾";
+    color: var(--MENU-SECTIONS-LINK-color, #bababa);
+}
+
 #sidebar ul.collapsible-menu li.active > a {
     margin-left: 0;
     padding-left: 0.5rem;


### PR DESCRIPTION
Added an option to allow the menu in the sidebar (the tree of topics) to be displayed collapsibly.

This is the content of a pull request https://github.com/matcornic/hugo-theme-learn/pull/526 issued to matcornic/hugo-theme-learn.

CSS, input[type=checkbox] tag, and label tag are used to dynamically open and close the menu tree.

## examples

<http://hugo-theme-relearn-examples.s3-website-ap-northeast-1.amazonaws.com>

### source

<https://github.com/poad/hugo-relearn-example>

