### PR TITLE
exampleSite: fix editURL

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,7 +27,7 @@ title = "Hugo Relearn Documentation"
 # settings specific to this theme's features; choose to your likings and
 # consult this documentation for explaination
 [params]
-  editURL = "https://github.com/McShelby/hugo-theme-relearn/edit/main/exampleSite/content"
+  editURL = "https://github.com/McShelby/hugo-theme-relearn/edit/main/exampleSite/content/"
   description = "Documentation for Hugo Relearn Theme"
   author = "Sören Weber"
   showVisitedLinks = true


### PR DESCRIPTION
This fixes the edit url button on your example site.