### PR TITLE
theme: improve font loading

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -8,6 +8,7 @@
     font-style: normal;
     font-weight: 200;
     src: url("../fonts/WorkSans-ExtraLight.woff") format("woff2"), url("../fonts/WorkSans-ExtraLight.woff") format("woff");
+    font-display: swap;
 }
 
 @font-face {
@@ -15,6 +16,7 @@
     font-style: normal;
     font-weight: 300;
     src: url("../fonts/WorkSans-Light.woff2") format("woff2"), url("../fonts/WorkSans-Light.woff") format("woff");
+    font-display: swap;
 }
 
 @font-face {
@@ -22,6 +24,7 @@
     font-style: normal;
     font-weight: 400;
     src: url("../fonts/WorkSans-Regular.woff2") format("woff2"), url("../fonts/WorkSans-Regular.woff") format("woff");
+    font-display: swap;
 }
 
 @font-face {
@@ -29,6 +32,7 @@
     font-style: normal;
     font-weight: 500;
     src: url("../fonts/WorkSans-Medium.woff2") format("woff2"), url("../fonts/WorkSans-Medium.woff") format("woff");
+    font-display: swap;
 }
 
 @font-face {
@@ -36,6 +40,7 @@
     font-style: normal;
     font-weight: 600;
     src: url("../fonts/WorkSans-Bold.woff2") format("woff2"), url("../fonts/WorkSans-Bold.woff") format("woff");
+    font-display: swap;
 }
 
 body {


### PR DESCRIPTION
It is usually recommended to add  `font-display: swap;` to `@font-face` definitions.
This will speed up font loading for the user mainly on initial page load. Without `font-display: swap;` the users sees no fonts before the web font is loaded. With `font-display: swap;` a fallback font is used (for that blink of a second).

See https://fontsplugin.com/google-fonts-font-display-swap/