### PR TITLE
Fix HTML closing tags in footer.html

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,10 +3,10 @@
             <i class='fas fa-user'></i> <a href="mailto:{{ $.Params.LastModifierEmail }}">{{ . }}</a> {{ with $.Date }} <i class='fas fa-calendar'></i> {{ .Format "02/01/2006" }}{{ end }}
           {{- end }}
           </footer>
+        </main><!-- #body-inner -->
         {{- if .Params.chapter }}
         </div> <!-- end chapter-->
         {{- end }}
-        </main><!-- #body-inner -->
 {{- partial "custom-comments.html" . }}
       </div>
     </div><!-- #body -->


### PR DESCRIPTION
The HTML closing tags for #chatper and #body-inner in footer.html are in wrong order. The #chapter block should enclose the #body-inner block. 