### PR TITLE
Improve Japanese translation of default titles

### DIFF
--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -44,13 +44,13 @@ other = "KB"
 other = "MB"
 
 [note]
-other = "手記"
+other = "メモ"
 
 [info]
 other = "情報"
 
 [tip]
-other = "先端"
+other = "ヒント"
 
 [warning]
 other = "警告"


### PR DESCRIPTION
Improve Japanese translation of some default titles for `notice` shortcode.
Current translation looks unnatural for native Japanese speaker.