### PR TITLE
Fixing errors thrown when using theme with hugo v0.112.x

### DIFF
--- a/layouts/partials/shortcodes/attachments.html
+++ b/layouts/partials/shortcodes/attachments.html
@@ -32,9 +32,9 @@
 <div class="box attachments cstyle {{ $style }}"{{ if $color }} style="--VARIABLE-BOX-color: {{ $color }};"{{ end }}>
   <div class="box-label">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ $title | markdownify }}</div>
   <ul class="box-content attachments-files">
-  {{- $fileLink := printf "%s/%s" (.Language.ContentDir | default "content") .File.Dir }}
+  {{- $fileLink := printf "%s/%s" ($.hugo.workingDir | default "content") .File.Dir }}
   {{- $fileLink = replace (replace $fileLink "\\" "/") "content/" "" }}
-  {{- $fileDir := printf "%s/%s" (.Language.ContentDir | default "content") .File.Dir  }}
+  {{- $fileDir := printf "%s/%s" ($.hugo.workingDir | default "content") .File.Dir  }}
   {{- $fileDir = replace $fileDir "\\" "/" }}
   {{- $filesName := printf "%s.files" .File.BaseFileName }}
   {{- if and (eq .File.BaseFileName "index") (fileExists (printf "%sfiles" $fileDir)) }}


### PR DESCRIPTION
When running the example site with latest released hugo version 0.112.3, errors are thrown:

```
Error: error building site: "/home/andreas/hugo-theme-relearn/exampleSite/content/shortcodes/attachments.en.md:8:1": failed to render shortcode "attachments": failed to process shortcode: execute of template failed: template: shortcodes/attachments.html:2:4: executing "shortcodes/attachments.html" at <partial "shortcodes/attachments.html" (dict "context" .Page "color" (.Get "color") "content" .Inner "icon" (.Get "icon") "pattern" (.Get "pattern") "style" (.Get "style") "sort" (.Get "sort") "title" (.Get "title"))>: error calling partial: "/home/andreas/hugo-theme-relearn/layouts/partials/shortcodes/attachments.html:35:44": execute of template failed: template: partials/shortcodes/attachments.html:35:44: executing "partials/shortcodes/attachments.html" at <.Language.ContentDir>: can't evaluate field ContentDir in type *langs.Language
```

This PR closes #540.