### PR TITLE
Fixed missing .Site.Params.additionalContentLanguage in search partial

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -12,7 +12,11 @@
         </div>{{ if $link }}</form>{{ end }}
         {{- $assetBusting := not .Site.Params.disableAssetsBusting }}
         {{- $pageBaseLang := replaceRE "([a-z]+).*" "${1}" .Page.Lang }}
-        {{- $contentlangs := (union (slice | append .Site.Params.additionalContentLanguage) (slice $pageBaseLang)) }}
+        {{- $contentlangs := slice $pageBaseLang -}}
+        {{- $additionalContentLanguage := .Site.Params.additionalContentLanguage -}}
+        {{- if and $additionalContentLanguage (ne (len $additionalContentLanguage) 0) -}}
+          {{- $contentlangs = union $contentlangs (slice $additionalContentLanguage) -}}
+        {{- end -}}
         {{- $quotedcontentlangs := slice }}
         {{- $missingcontentlangs := slice }}
         {{- range $contentlangs }}


### PR DESCRIPTION
I had a bizarre error- with no change  that I  can spot under `content`, a site which was previously building failed with:  
` execute of template failed: template: partials/search.html:16:19: executing "partials/search.html" at <len .Site.Params.additionalContentLanguage>: error calling len: reflect: call of reflect.Value.Type on zero Value`

I tried defining the property in all content pages and in hugo.yml, but it didn't work.

Disclaimer, this code was generated by chatgpt! so if that's unacceptable, or if there's some configuration I'm missing, I apologize and would appreciate being corrected :)