### PR TITLE
Use $context.Page for .RenderString for shortcode reuse in partials

### DIFF
--- a/layouts/partials/shortcodes/attachments.html
+++ b/layouts/partials/shortcodes/attachments.html
@@ -40,7 +40,7 @@
   {{- end }}
 {{- end }}
 <div class="box attachments cstyle {{ $style }}"{{ if $color }} style="--VARIABLE-BOX-color: {{ $color }};"{{ end }}>
-  <div class="box-label">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ $title | .RenderString }}</div>
+  <div class="box-label">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ $title | $context.Page.RenderString }}</div>
   <ul class="box-content attachments-files">
   {{- $fileDir := "" }}
   {{- if or (and (eq $major 0) (ge $minor 112)) (gt $major 0) }}

--- a/layouts/partials/shortcodes/badge.html
+++ b/layouts/partials/shortcodes/badge.html
@@ -16,5 +16,5 @@
   {{- $icon = printf "fa-fw fas fa-%s" $icon }}
 {{- end }}
 {{- with $context -}}
-<span class="badge cstyle {{ $style }}{{ if or $icon $title }} badge-with-title{{ end }}">{{ if or $icon $title }}<span class="badge-title">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ if $title }}{{ $title | .RenderString }}{{ end }}</span>{{ end }}<span class="badge-content"{{ if $color }} style="background-color: {{ $color }};"{{ end }}>{{ $content }}</span></span>
+<span class="badge cstyle {{ $style }}{{ if or $icon $title }} badge-with-title{{ end }}">{{ if or $icon $title }}<span class="badge-title">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ if $title }}{{ $title | $context.Page.RenderString }}{{ end }}</span>{{ end }}<span class="badge-content"{{ if $color }} style="background-color: {{ $color }};"{{ end }}>{{ $content }}</span></span>
 {{- end }}

--- a/layouts/partials/shortcodes/expand.html
+++ b/layouts/partials/shortcodes/expand.html
@@ -13,7 +13,7 @@
     <label class="expand-label" for="expand-{{ $id }}" >
         <i class="fas fa-chevron-down"></i>
         <i class="fas fa-chevron-right"></i>
-        {{ $title | .RenderString }}
+        {{ $title | $context.Page.RenderString }}
     </label>
     <div id="expandcontent-{{ $id }}" class="expand-content">
 {{ if ne "<" (substr (strings.TrimLeft " \n\r\t" $content) 0 1) }}<p>{{ end }}<!-- we add a DOM element here if there is none to make collapsing marings work -->

--- a/layouts/partials/shortcodes/notice.html
+++ b/layouts/partials/shortcodes/notice.html
@@ -17,7 +17,7 @@
 {{- end }}
 {{- with $context }}
 <div class="box notices cstyle {{ $style }}"{{ if $color }} style="--VARIABLE-BOX-color: {{ $color }};"{{ end }}>
-  <div class="box-label">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ $title | .RenderString }}</div>
+  <div class="box-label">{{ if $icon }}<i class="{{ $icon }}"></i>{{ end }}{{ if and $icon $title }} {{ end }}{{ $title | $context.Page.RenderString }}</div>
   <div class="box-content">
 {{ if ne "<" (substr (strings.TrimLeft " \n\r\t" $content) 0 1) }}<p>{{ end }}<!-- we add a DOM element here if there is none to make collapsing marings work -->
 {{ $content | safeHTML }}</div><!-- no line break allowed here because of awkward behavior of Hugo 110 or this theme when tag shortcode is called standalone outside of tags shortcode ? -->


### PR DESCRIPTION
Following the fix https://github.com/McShelby/hugo-theme-relearn/commit/61f05936b1e10fd84038adb821d19c0be6efcbf2 for https://github.com/McShelby/hugo-theme-relearn/issues/555, using the partials/shortcodes inside another shortcode would yield the following error:

`executing "my-custom-shortcode.html" at <partial "shortcodes/expand.html" (dict "context" . "title" $title "content" $content)>: error calling partial: "/themes/relearn/layouts/partials/shortcodes/expand.html:16:28": execute of template failed: template: partials/shortcodes/expand.html:16:28: executing "partials/shortcodes/expand.html" at <$context.RenderString>: RenderString is not a method but has arguments`

This PR instead relies on the $context to provide the .Page instead of trying to access . as if it was used in the page context.
