### PR TITLE
Fix spelling in Swagger Docs

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -350,7 +350,7 @@ function initOpenapi( update, attrs ){
                 '</head>' +
                 '<body>' +
                     '<a class="relearn-expander" href="" onclick="return relearn_collapse_all()">Collapse all</a>' +
-                    '<a class="relearn-expander" href="" onclick="return relearn_expand_all()">Exapnd all</a>' +
+                    '<a class="relearn-expander" href="" onclick="return relearn_expand_all()">Expand all</a>' +
                     '<div id="relearn-swagger-ui"></div>' +
                     '<script>' +
                         'function relearn_expand_all(){' +


### PR DESCRIPTION
There is a spelling mistake in the Swagger Docs.

`Exapnd` to `Expand`