### PR TITLE
Added fix for failing attachment when the directory container upper case chars

### DIFF
--- a/layouts/partials/shortcodes/attachments.html
+++ b/layouts/partials/shortcodes/attachments.html
@@ -53,7 +53,7 @@
     {{- $fileDir = printf "%s/%s" (path.Clean (.Language.ContentDir | default "content")) (path.Clean .File.Dir) }}
   {{- end }}
   {{- $fileDir = printf "%s/" (path.Clean (strings.TrimPrefix "/" $fileDir)) }}
-  {{- $fileLink := $fileDir }}
+  {{- $fileLink := lower ($fileDir) }}
   {{- $fileLink = strings.TrimPrefix "content/" $fileLink }}
   {{- $filesName := printf "%s.files" .File.BaseFileName }}
   {{- if and (eq .File.BaseFileName "index") (fileExists (printf "%sfiles" $fileDir)) }}


### PR DESCRIPTION
I came across an issue when using attachments. My directory folder on disk contained upper case chars, e.g. 

```
content/
├─ Day1/
│  ├─ index.md
│  ├─ index.files/
│  │  ├─ file.zip
```

The url generated by the the template for this attachment would be `/Day1/index.files/file.zip` but Hugo (0.118.2) forces lowercase paths. So `/Day1/` is redirected to `/day1/`. Hence, the generated URL doesn't work. 

The fix is to have the filelink all lower case, while the filename DOES retain it's casing.