### PR TITLE
topbar: edit button supports page editURL param before site one

### DIFF
--- a/layouts/partials/topbar/button/edit.html
+++ b/layouts/partials/topbar/button/edit.html
@@ -4,12 +4,12 @@
 {{- with .page }}
 	{{- $format := partial "get-format.hugo" . }}
 	{{- $outputFormat := partial "output-format.hugo" (dict "page" . "format" $format) }}
-	{{- $editURL := .Site.Params.editURL | default "" }}
-	{{- if and (eq $outputFormat "html") $editURL .File }}
+	{{- if and (eq $outputFormat "html") (or .Site.Params.editURL .Params.editURL) .File }}
+		{{- $href := or .Params.editURL (printf "%s%s%s" .Site.Params.editURL (strings.TrimLeft "/" (replace .File.Dir "\\" "/")) .File.LogicalName) }}
 		{{- partial "topbar/func/button.html" (dict
 			"page" .
 			"class" "topbar-button-edit"
-			"href" (printf "%s%s%s" $editURL (strings.TrimLeft "/" (replace .File.Dir "\\" "/")) .File.LogicalName)
+			"href" $href
 			"icon" "pen"
 			"onwidths" $onwidths
 			"onwidthm" $onwidthm


### PR DESCRIPTION
The rationale is that sometimes a page could be edited using a different URL than the declared site schema.
With this PR, a page can override the global URL schema giving its own already complete URL.
It also allows not to set the site editURL param, but only set it in a few pages that can be edited.

The docs have to be changed, but I wanted to check whether the idea is worth it or not before doing it.