### PR TITLE
fix missing ending shortcode tag

### DIFF
--- a/exampleSite/content/shortcodes/notice.en.md
+++ b/exampleSite/content/shortcodes/notice.en.md
@@ -118,6 +118,7 @@ A **notice** disclaimer
 ````go
 {{%/* notice style="tip" */%}}
 A **tip** disclaimer
+{{% /notice %}}
 ````
 
 {{% notice style="tip" %}}


### PR DESCRIPTION
The closing shortcode tag is missing in the example code. My PR adds it.