### PR TITLE
Added option to site Params for customizing the theme selection icon.

### DIFF
--- a/exampleSite/content/basics/branding/_index.en.md
+++ b/exampleSite/content/basics/branding/_index.en.md
@@ -44,6 +44,13 @@ The theme provides an advanced configuration mode, combining the functionality f
 Although all options documented here are still working, the advanced configuration options are the recommended way to configure your color variants. [See below](#theme-variant-advanced).
 {{% /notice %}}
 
+#### Custom Theme Selection Icon
+
+{{< multiconfig file=hugo >}}
+[params]
+  themeSelectIcon = "fa-adjust" # defaults to "fa-paint-brush"
+{{< /multiconfig >}}
+
 ## Adjust to OS Settings
 
 You can also cause the site to adjust to your OS settings for light/dark mode. Just set the `themeVariant` to `auto` to become an auto mode variant. That's it.

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -86,7 +86,9 @@
               </li>
               <li id="R-select-variant-container" class="footerVariantSwitch{{if $showvariantswitch}} showVariantSwitch{{end}}">
                 <div class="padding menu-control">
-                  <i class="fa-fw fas fa-paint-brush"></i>
+                  {{- $themeselecticon := "fa-paint-brush" -}}
+                  {{- with .Site.Params.themeSelectIcon -}}{{- $themeselecticon = . -}}{{- end -}}
+                  <i class="fa-fw fas {{ $themeselecticon }}"></i>
                   <span>&nbsp;</span>
                   <div class="control-style">
                     <label class="a11y-only" for="R-select-variant">{{ T "Theme" }}</label>


### PR DESCRIPTION
I was building a help system with light/dark theme selection and preferred a different icon for the theme selector (fa-adjust).  This PR makes it possible to set the font-awesome class in the site configuration params using e.g.

```toml
[params]
  themeSelectIcon = "fa-adjust"
```