### PR TITLE
Fix deprecation warnings for .Sites.First and .Site.IsMultiLingual

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
     {{- $basename = partial "BaseName.hugo" $format.RelPermalink }}
   {{- end }}
 {{- end }}
-{{- if eq . .Site.Sites.First.Home }}
+{{- if eq . .Site.Sites.Default.Home }}
   {{- $hugoVersion := "0.121.0" }}
   {{- if lt hugo.Version $hugoVersion }}
     {{- errorf "The Relearn theme requires Hugo %s or later" $hugoVersion }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -59,7 +59,7 @@
         </div>
         {{- end }}
         {{- $siteLanguages := .Site.Languages }}
-        {{- $showlangswitch := and .Site.IsMultiLingual (not .Site.Params.disableLanguageSwitchingButton) (gt (int (len $siteLanguages)) 1) }}
+        {{- $showlangswitch := and hugo.IsMultilingual (not .Site.Params.disableLanguageSwitchingButton) (gt (int (len $siteLanguages)) 1) }}
         {{- $themevariants := partialCached "get-theme-variants.hugo" . }}
         {{- $showvariantswitch := gt (int (len $themevariants)) 1 }}
         {{- $footer := partial "menu-footer.html" . }}


### PR DESCRIPTION
This fixes the warnings mentioned in the issue https://github.com/McShelby/hugo-theme-relearn/issues/920#issue-2540511134