### PR TITLE
Fix searchindexurl handling for BaseURLs with folders

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -11,14 +11,14 @@
           {{- warnf "UNSUPPORTED usage of 'searchpage' output format found, remove it from your config; see https://mcshelby.github.io/hugo-theme-relearn/introduction/releasenotes/7/#7-0-0" }}
         {{- end }}
         {{- if not .Site.Params.disableSearchIndex }}
-          {{- $url := path.Join .Site.LanguagePrefix (trim (or .Site.Params.searchIndexURL "searchindex.js") "/") }}
+          {{- $url := path.Join (trim (or .Site.Params.searchIndexURL "searchindex.js") "/") }}
           {{- if .IsHome }}
             {{- $templateres := resources.Get "_relearn_searchindex.js" }}
             {{- $resultres := $templateres | resources.ExecuteAsTemplate $url .Site.Home }}
             {{- /* the following code causes Hugo to generate our file - although it is in comments */}}<!-- {{ $resultres.RelPermalink }} -->
           {{- end }}
         <script>
-          window.index_js_url={{ (printf "%s%s" $url $assetBusting) | relLangURL }};
+          window.index_js_url={{ (printf "%s%s" $url $assetBusting) | relURL }};
         </script>
           {{- if not .Site.Params.disableSearchPage }}
             {{- with .Site.GetPage "_relearn_searchpage" }}


### PR DESCRIPTION
Related to #940

Update `search.html` to handle BaseURLs with folders correctly and remove artificial language code prefixing.

* Remove `.Site.LanguagePrefix` from the `$url` variable construction.
* Change `relLangURL` to `relURL` for `window.index_js_url`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/McShelby/hugo-theme-relearn/issues/940?shareId=ce5b8113-7506-4f6d-93dd-7789b3bfbf2c).