### PR TITLE
Removing RenderString fix taxonomy and term render

### DIFF
--- a/layouts/partials/bodys/taxonomy.html
+++ b/layouts/partials/bodys/taxonomy.html
@@ -5,7 +5,7 @@
 
 {{- $title := partial "title.gotmpl" (dict "page" .) }}
 <h1 id="{{ $title | plainify | anchorize }}">{{ $title }}</h1>
-{{ partial "partials/shortcodes/taxonomy.html" (dict "page" . "taxonomy" .) | .RenderString }}
+{{ partial "partials/shortcodes/taxonomy.html" (dict "page" . "taxonomy" .) }}
 
   <footer class="footline">
   </footer>

--- a/layouts/partials/bodys/term.html
+++ b/layouts/partials/bodys/term.html
@@ -5,7 +5,7 @@
 
 {{- $title := partial "title.gotmpl" (dict "page" .) }}
 <h1 id="{{ $title | plainify | anchorize }}">{{ $title }}</h1>
-{{ partial "partials/shortcodes/term.html" (dict "page" . "term" .) | .RenderString }}
+{{ partial "partials/shortcodes/term.html" (dict "page" . "term" .) }}
 
   <footer class="footline">
   </footer>


### PR DESCRIPTION
The taxonomy and terms pages display a blank page below the title.

To be sure, I've created a fresh new site with the [Getting Start tutorial](https://mcshelby.github.io/hugo-theme-relearn/introduction/quickstart/index.html#create-content) and I got the same blank content.

Removing the `.RenderString` in both `layouts/partials/bodys/taxonomy.html` and `layouts/partials/bodys/term.html` templates fix the problem in my configuration.

