### PR TITLE
Removed white-space nowrap from code element to align with HTML specification (and better support Atlassian Confluence HTML output in Hugo)

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -943,7 +943,6 @@ code {
   color-adjust: economy;
   padding-left: 2px;
   padding-right: 2px;
-  white-space: nowrap;
 }
 
 span.copy-to-clipboard {


### PR DESCRIPTION
HTML `code` element is not defined as having preformatted content, therefore there should not be `white-space: nowrap` applied to it. This is causing issues when using the theme with HTML generated by Atlassian Confluence that uses the `<code>` element for non-proportional character text style.

The HTML specification has examples that explain that `<code>` is an inline element to change the font to nonproportional, and if you need to preserve whitespace, you need to encapsulate the `<code>` into an outer `<pre>` element: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element

This is the example from the HTML spec that combines `<pre>` and `<code>`:

```
<pre><code class="language-pascal">var i: Integer;
begin
   i := 1;
end.</code></pre>
```