### PR TITLE
Fix H1 letter spacing and H1 font familly definitions

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -23,7 +23,7 @@
     --INTERNAL-MAIN-TITLES-letter-spacing: var(--MAIN-TITLES-letter-spacing, var(--INTERNAL-MAIN-letter-spacing));
 
     --INTERNAL-MAIN-TITLES-H1-TEXT-color: var(--MAIN-TITLES-H1-TEXT-color, var(--MAIN-TITLES-H1-color, var(--INTERNAL-MAIN-TEXT-color)));
-    --INTERNAL-MAIN-TITLES-H1-font: var(--MAIN-TITLES-H1-font, var(--INTERNAL-MAIN-font));
+    --INTERNAL-MAIN-TITLES-H1-font: var(--MAIN-TITLES-H1-font, var(--INTERNAL-MAIN-TITLES-font));
     --INTERNAL-MAIN-TITLES-H1-font-variation-settings: var(--MAIN-TITLES-H1-font-variation-settings, "wdth" 118, "GRAD" -100, "YTFI" 710);
     --INTERNAL-MAIN-TITLES-H1-font-weight: var(--MAIN-TITLES-H1-font-weight, 200);
     --INTERNAL-MAIN-TITLES-H1-letter-spacing: var(--MAIN-TITLES-H1-letter-spacing, var(--INTERNAL-MAIN-TITLES-letter-spacing));

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -26,7 +26,7 @@
     --INTERNAL-MAIN-TITLES-H1-font: var(--MAIN-TITLES-H1-font, var(--INTERNAL-MAIN-font));
     --INTERNAL-MAIN-TITLES-H1-font-variation-settings: var(--MAIN-TITLES-H1-font-variation-settings, "wdth" 118, "GRAD" -100, "YTFI" 710);
     --INTERNAL-MAIN-TITLES-H1-font-weight: var(--MAIN-TITLES-H1-font-weight, 200);
-    --INTERNAL-MAIN-TITLES-H1-letter-spacing: var(--MAIN-TITLES-H1-letter-spacing, var(--INTERNAL-MAIN-letter-spacing));
+    --INTERNAL-MAIN-TITLES-H1-letter-spacing: var(--MAIN-TITLES-H1-letter-spacing, var(--INTERNAL-MAIN-TITLES-letter-spacing));
 
     --INTERNAL-MAIN-TITLES-H2-TEXT-color: var(--MAIN-TITLES-H2-TEXT-color, var(--MAIN-TITLES-H2-color, var(--INTERNAL-MAIN-TITLES-TEXT-color)));
     --INTERNAL-MAIN-TITLES-H2-font: var(--MAIN-TITLES-H2-font, var(--INTERNAL-MAIN-TITLES-font));


### PR DESCRIPTION
Unless I am mistaken the H1 should also prefer `--MAIN-TITLES-*` just like H2, H3 and the rest of it?

At least for me it makes sense. Had to work around this before, but now I had to add a second workaround for H1 letter spacing, so I thought maybe I should contribute this back.

Unless there is a reason for H1 to prefer non-`TITLES` settings? To me it does not make sense.