### PR TITLE
versioning: add unique class to warning

### DIFF
--- a/layouts/partials/versioning-warning.html
+++ b/layouts/partials/versioning-warning.html
@@ -1,5 +1,6 @@
 {{- partial "shortcodes/notice.html" (dict
   "page" .page
+  "class" "versioning-warning"
   "content" (T "Versioning-warning" (dict "pageUrl" .pageUrl "pageVersion" .pageVersion "latestUrl" .latestUrl "latestVersion" .latestVersion ))
   "icon" " "
   "style" "warning"


### PR DESCRIPTION
This commit adds a unique class to the versioning warning partial.

Yes it can be modified as a partial, but this allows it to be styled using css as well.