### PR TITLE
theme: set code font-size to percent

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -980,7 +980,7 @@ code,
 kbd,
 pre:not(.mermaid),
 samp {
-  font-size: 0.934375rem;
+  font-size: 92%;
   font-variation-settings: var(--INTERNAL-CODE-font-variation-settings);
   font-weight: var(--INTERNAL-CODE-font-weight);
   font-family: var(--INTERNAL-CODE-font);


### PR DESCRIPTION
Your theme used to define code font-size in percent. I never understood the reason, but now I do, consider this:


![image](https://github.com/user-attachments/assets/1dce26d7-59d8-4021-bd23-5e466870d32a)
https://mcshelby.github.io/hugo-theme-relearn/configuration/content/linking/index.html#patching-the-relref-shortcode

If the inline code is used within a title for example, we want the font size to be consistent within it's context.

For that reason I am proposing to "revert" back to 92% (as it used to be), as this this provides a consistent look:

![image](https://github.com/user-attachments/assets/49e89ebf-ff85-4935-a112-49999e0909b9)
