### PR TITLE
theme: remove redundant 1 pixel border in sidebar

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -2718,14 +2718,6 @@ body #R-logo svg :not([fill='#000000']) {
   }
 }
 
-#R-header-wrapper,
-#R-homelinks,
-#R-content-wrapper > * {
-  border-inline-end-color: var(--INTERNAL-MENU-BORDER-color);
-  border-inline-end-style: solid;
-  border-inline-end-width: 1px;
-}
-
 #topics > ul {
   margin-top: 1rem;
 }


### PR DESCRIPTION
This commit removes a 1 pixel border in the sidebar. I do not see any reason for it's existence.

Frankly it is not apparent in your theme, but in our gobolinux theme it is visible (until I patched it).

But to highlight the change, here is your theme but with a red sidebar background:
![image](https://github.com/user-attachments/assets/445b7a65-d673-40c8-9e0c-2ad19fbb691e)

After the patch:
![image](https://github.com/user-attachments/assets/2cab42da-2898-414f-bb03-d0dda721e3b7)

The original "hugo learn theme" did not have such a 1 pixel border neither, so I suppose it is redundant.