### PR TITLE
Fixed spelling mistake in es.toml

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -110,7 +110,7 @@ other = "Copiar enlace al portapapeles"
 other = "¡Enlace copiado al portapapeles!"
 
 [Chapter]
-other = "Capitulo {{.}}"
+other = "Capítulo {{.}}"
 
 [Language]
 other = "Idioma"


### PR DESCRIPTION
"Capitulo" should be (here) "Capítulo" (otherwise it's a verb).