### PR TITLE
Refactor: Improve language switcher UI

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -2951,6 +2951,58 @@ body.notfound #shrug svg {
   --VARIABLE-BOX-TEXT-color: var(--INTERNAL-MAIN-TEXT-color);
 }
 
+/* Language Switcher Styles */
+.R-languageswitcher {
+  /* Container for the language switcher if specific container styling is needed */
+  /* For now, assuming it's an <li> in a menu, so direct styling might not be needed here */
+}
+
+.R-languageswitcher .language-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap; /* Allows items to wrap to the next line on smaller screens */
+  align-items: center; /* Vertically align items if they wrap and have different heights */
+}
+
+.R-languageswitcher .language-list li {
+  margin: 0; /* Reset margin */
+  padding: 0; /* Reset padding */
+}
+
+.R-languageswitcher .language-list li a {
+  display: flex; /* Align icon and text */
+  align-items: center;
+  padding: 0.5rem 0.75rem; /* Adjust padding to match theme's link styling - this is a guess */
+  text-decoration: none;
+  color: var(--INTERNAL-MENU-SECTIONS-LINK-color); /* Using a variable that seems relevant for sidebar links */
+  white-space: nowrap; /* Prevent line breaks within a single language option */
+}
+
+.R-languageswitcher .language-list li a:hover,
+.R-languageswitcher .language-list li a:focus {
+  color: var(--INTERNAL-MENU-SECTIONS-LINK-HOVER-color); /* Using a hover color variable */
+  background-color: var(--INTERNAL-MENU-HOVER-color); /* A guess for hover background, might need adjustment */
+  text-decoration: none; /* Ensure no underline on hover if not desired */
+}
+
+.R-languageswitcher .language-list li.active a {
+  color: var(--INTERNAL-MENU-SECTION-ACTIVE-CATEGORY-color); /* Style for the active language */
+  font-weight: bold; /* Make active language bold */
+}
+
+.R-languageswitcher .language-list li a i {
+  margin-right: 0.5em; /* Space between icon and text */
+  font-size: 1em; /* Ensure icon size matches text size */
+  line-height: 1; /* Ensure icon aligns well with text */
+}
+
+/* Responsive considerations:
+   - flex-wrap: wrap on .language-list already allows basic wrapping.
+   - Further specific responsive adjustments might be needed depending on theme context.
+*/
+
 .cstyle.secondary {
   --VARIABLE-BOX-color: var(--INTERNAL-SECONDARY-color);
   --VARIABLE-BOX-TEXT-color: var(--INTERNAL-MAIN-TEXT-color);

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1463,11 +1463,13 @@ function handleHistoryClearer() {
 }
 
 function handleLanguageSwitcher() {
-  document.querySelectorAll('.R-languageswitcher select').forEach(function (select) {
-    select.addEventListener('change', function (event) {
-      const url = this.options[`R-select-language-${this.value}`].dataset.url;
-      this.value = this.querySelector('[data-selected]')?.value ?? select.value;
-      window.location = url;
+  document.querySelectorAll('.R-languageswitcher ul.language-list li a').forEach(function (link) {
+    link.addEventListener('click', function (event) {
+      event.preventDefault();
+      const url = this.href;
+      if (url) {
+        window.location.href = url;
+      }
     });
   });
 }

--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -357,7 +357,36 @@ disableShortcutsTitle = false
 # If not given, defaults to
 # - a home button if configured; if you redefine this, use a Hugo menu and a type=menu to replicate this
 # - a divider to separate from the sidebarmenus (depending on the configuration of the theme variant)
-sidebarheadermenus = ''
+# sidebarheadermenus = '' # Old value, using theme defaults
+
+# Custom sidebar header menu to include language switcher at the top
+[[params.sidebarheadermenus]]
+  type = "divider"
+[[params.sidebarheadermenus]]
+  type = "menu"
+  identifier = "homelinks" # Replicates default home button behavior
+  disableTitle = true
+  [[params.sidebarheadermenus.entries]]
+    Pre = "<i class='fa-fw fas fa-home'></i> "
+    Title = "Home" # Actual title will be from i18n T "home-button"
+    PageRef = "/"
+[[params.sidebarheadermenus]]
+  type = "divider"
+[[params.sidebarheadermenus]]
+  type = "custom"
+  identifier = "languageswitchertop"
+  [[params.sidebarheadermenus.elements]]
+    type = "languageswitcher"
+    icon = "language"
+[[params.sidebarheadermenus]]
+  type = "divider"
+[[params.sidebarheadermenus]]
+  type = "custom"
+  identifier = "headercontrols" # Replicates default version switcher
+  [[params.sidebarheadermenus.elements]]
+    type = "versionswitcher"
+[[params.sidebarheadermenus]]
+  type = "divider"
 
 # The main sidebar header.
 # Default: see notes
@@ -371,7 +400,18 @@ sidebarmenus = ''
 # - the language switcher if multilingual is configured
 # - the variant switcher if multiple variants are configured
 # - the history clearer if you configured to mark visited pages
-sidebarfootermenus = ''
+# sidebarfootermenus = '' # Old value, using theme defaults
+
+# Custom sidebar footer menu to exclude language switcher
+[[params.sidebarfootermenus]]
+  type = "divider"
+[[params.sidebarfootermenus]]
+  type = "custom"
+  identifier = "myfootercontrols"
+  [[params.sidebarfootermenus.elements]]
+    type = "variantswitcher"
+  [[params.sidebarfootermenus.elements]]
+    type = "historyclearer"
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Hidden pages

--- a/layouts/partials/sidebar/element/languageswitcher.html
+++ b/layouts/partials/sidebar/element/languageswitcher.html
@@ -7,17 +7,14 @@
   {{- end }}
 			<li class="R-languageswitcher">
               <div class="padding menu-control">
-                <i class="{{ $icon }}"></i>
-                <span>&nbsp;</span>
-                <div class="control-style">
-                  <label class="a11y-only" for="R-select-language">{{ T "Language" }}</label>
-                  <select id="R-select-language">
-                    {{- $pageLang := .page.Language.Lang }}
-                    {{- range .page.AllTranslations }}
-                    <option id="R-select-language-{{ .Language.Lang }}" value="{{ .Language.Lang }}" data-url="{{ partial "permalink.gotmpl" (dict "to" .) }}" lang="{{ .Language.LanguageCode }}"{{ if eq $pageLang .Language.Lang }} selected data-selected{{ end }}>{{ .Language.LanguageName }}</option>
-                    {{- end }}
-                  </select>
-                </div>
+                <ul class="language-list">
+                  {{- $pageLang := .page.Language.Lang }}
+                  {{- range .page.AllTranslations }}
+                  <li lang="{{ .Language.LanguageCode }}"{{ if eq $pageLang .Language.Lang }} class="active"{{ end }}>
+                    <a href="{{ partial "permalink.gotmpl" (dict "to" .) }}"><i class="{{ $icon }}"></i> {{ .Language.LanguageName }}</a>
+                  </li>
+                  {{- end }}
+                </ul>
                 <div class="clear"></div>
               </div>
             </li>


### PR DESCRIPTION
This commit enhances the language selection user interface in the theme.

The previous language switcher was a small dropdown at the bottom of the sidebar, which could be hard to notice.

This change implements the following improvements:
- Replaces the dropdown with a list of language links, each accompanied by a language icon.
- Relocates the language switcher to a more prominent position at the top of the sidebar for better visibility and accessibility.
- Updates the relevant HTML partial (`languageswitcher.html`), JavaScript (`theme.js` for event handling), and CSS (`theme.css` for styling).
- Modifies `params.toml` to control the new positioning of the switcher within the sidebar menu structure.

The new language switcher provides a clearer and more user-friendly way for users to switch between available languages on the documentation site.