### PR TITLE
docs: fix two small typos

### DIFF
--- a/docs/content/configuration/sidebar/menus/_index.en.md
+++ b/docs/content/configuration/sidebar/menus/_index.en.md
@@ -269,7 +269,7 @@ Notes:
 
 ### Page Menu
 
-The page menu generates a menu tree out of your directory structure. You can give it a starting page from where the tree is generated down. If now starting page is given, the home page is used.
+The page menu generates a menu tree out of your directory structure. You can give it a starting page from where the tree is generated down. If no starting page is given, the home page is used.
 
 | Name                  | Default         | Notes       |
 |-----------------------|-----------------|-------------|

--- a/docs/content/development/contributing/_index.en.md
+++ b/docs/content/development/contributing/_index.en.md
@@ -28,7 +28,7 @@ Check for unnecessary whitespace and correct indention of your resulting HTML.
 
 Write commit messages in the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
-Following is an inpomplete list of some of the used conventional commit types. Be creative.
+Following is an incomplete list of some of the used conventional commit types. Be creative.
 
 | Common     | Feature    | Structure       | Shortcodes  |
 |------------|------------|-----------------|-------------|


### PR DESCRIPTION
- correct typo in configuration/sidebar/menus
- correct typo in development/contributing