### PR TITLE
Change German translation for versioning warning

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -2,7 +2,7 @@
 other = "ltr"
 
 [Versioning-warning]
-other = 'Du liest gerade die Version {{.pageVersion.title}} dieser Seite. Die aktuelle Version finden Sie <a href="{{.latestUrl}}">hier</a>.'
+other = 'Du liest gerade die Version {{.pageVersion.title}} dieser Seite. Die aktuelle Version ist <a href="{{.latestUrl}}">hier</a> zu finden.'
 
 [Search]
 other = "Suchen"


### PR DESCRIPTION
This PR changes the German translation for the versioning warning as outlined in #1139.