### PR TITLE
Fix `canonifyURLs` breaking `showVisitedLinks`

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1354,7 +1354,9 @@ function clearHistory() {
 
 function initHistory() {
   var visitedItem = window.relearn.absBaseUri + '/visited-url/';
-  window.relearn.setItem(window.sessionStorage, visitedItem + document.querySelector('body').dataset.url, 1);
+  // in case we have `canonifyURLs=true` we have to strip the base URI
+  var currentUrl = document.querySelector('body').dataset.url.replace(window.relearn.absBaseUri, '');
+  window.relearn.setItem(window.sessionStorage, visitedItem + currentUrl, 1);
 
   // loop through the sessionStorage and see if something should be marked as visited
   for (var item in window.sessionStorage) {


### PR DESCRIPTION
If you enable `canonifyURLs` in your Hugo config, then the `showVisitedLinks` features breaks. This is because `initHistory()` in `theme.js` stores the URL in the `sessionStorage` in the following way:

https://github.com/McShelby/hugo-theme-relearn/blob/8641811ed5627ef8ca1f8998f3ec43dd9b213871/assets/js/theme.js#L1356-L1357

However, when enabling `canonifyURLs` in Hugo, then the `data-url` attribute on the `<body>` will already contain an absolute URL, including the hostname. Thus Relearn stores 

```
//example.com/visited-url///example.com/foo/bar/
```

instead of just

```
//example.com/visited-url//foo/bar/
```

and thus the following comparison fails:

https://github.com/McShelby/hugo-theme-relearn/blob/8641811ed5627ef8ca1f8998f3ec43dd9b213871/assets/js/theme.js#L1361-L1369

This PR fixes that by removing `window.relearn.absBaseUri` from the `data-url` before storing into the `sessionStorage`.