### PR TITLE
i18n nl: Change "Fooi" to "Tip"

### DIFF
--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -89,7 +89,7 @@ other = "Info"
 other = "Notitie"
 
 [tip]
-other = "Fooi"
+other = "Tip"
 
 [warning]
 other = "Waarschuwing"


### PR DESCRIPTION
"Fooi" is not the correct Dutch word for a hint/tip.