### PR TITLE
Update comment to reflect correct front matter key

### DIFF
--- a/docs/content/authoring/frontmatter/reference/frontmatter.toml
+++ b/docs/content/authoring/frontmatter/reference/frontmatter.toml
@@ -187,7 +187,7 @@ collapsibleMenu = true
 # - `disableTitle`, boolean. If `true`, there is no title above the tree.
 #    Default: `true` for `type=page` and `false` for `type=menu`. If a title
 #    should be used, in case of `type=page` it will be taken from the page's
-#    `menuTitle` front matter and if not set, from the translation files, using
+#    `LinkTitle` front matter and if not set, from the translation files, using
 #    the menu `identifier` as key. In case of `type=menu` it will be taken
 #    from the menu `title` according to Hugo's documentation and if not set
 #    from the menu `name` and if this is not set form the page's `linkTitle`.


### PR DESCRIPTION
`menuTitle` had been deprecated  in #714 so I believe this should refer to `LinkTitle`