### PR TITLE
anchors: scroll content when clicking in-page anchor links #1238

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -631,6 +631,40 @@ function initAnchorClipboard() {
   }
 }
 
+
+function initAnchorScrolling() {
+  // scroll the content area when an in-page anchor link (eg. in the TOC
+  // flyout or a footnote) is clicked; the browser's default fragment
+  // navigation does not scroll our custom scroll container in all cases
+  document.addEventListener('click', function (event) {
+    if (event.defaultPrevented || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    var link = event.target.closest('a[href^="#"]');
+    if (!link) {
+      return;
+    }
+    var hash = link.getAttribute('href');
+    if (hash.length < 2) {
+      return;
+    }
+    var target = null;
+    try {
+      target = document.getElementById(decodeURIComponent(hash.substring(1)));
+    } catch (e) {
+      return;
+    }
+    if (!target) {
+      return;
+    }
+    event.preventDefault();
+    target.scrollIntoView({ behavior: 'smooth' });
+    let state = window.history.state || {};
+    state = Object.assign({}, typeof state === 'object' ? state : {});
+    history.pushState(state, '', hash);
+  });
+}
+
 function initCodeClipboard() {
   function getCodeText(node) {
     // if highlight shortcode is used in inline lineno mode, remove lineno nodes before generating text, otherwise it doesn't hurt
@@ -1823,6 +1857,7 @@ ready(function () {
   initMenuScrollbar();
   initToc();
   initAnchorClipboard();
+  initAnchorScrolling();
   initCodeClipboard();
   fixCodeTabs();
   restoreTabSelections();


### PR DESCRIPTION
Fixes #1238

### Problem

Clicking an in-page anchor link (TOC flyout entry, footnote, or any in-content `#fragment` link) updates the URL hash but does not scroll the content, because the theme scrolls its own container (`main#R-body-inner`) instead of the document and the browser's default fragment navigation does not reliably bring the target into view inside it. A full page load with the fragment in the URL works fine.

### Fix

Adds `initAnchorScrolling()`: a delegated click listener for `a[href^="#"]` links that scrolls the target into view and pushes the new hash, mirroring the pattern already used by the `scrollanchor` handler in `initAnchorClipboard()`. Modified clicks (ctrl/meta/shift/alt, non-primary button) and already-handled events (`defaultPrevented`) are left untouched.

### Tested

Verified on a real ~2500-page documentation site running theme 9.0.3 with Hugo 0.159.1 extended (Chromium): TOC flyout links, right-side TOC links and in-content fragment links now scroll correctly; heading copy-link buttons, tabs, expanders and normal navigation are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
